### PR TITLE
Add BackgroundLocation permission

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,12 +1,10 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.getcapacitor.community.bglocation.capacitorbackgroundgeolocation">
 
-  <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-      package="com.getcapacitor.community.bglocation.capacitorbackgroundgeolocation">
+  <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+  <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+  <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
 
-      <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
-      <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
-
-      <application>
-      <service android:enabled="true" android:name="com.getcapacitor.community.bglocation.LocationUpdatesService" />
-      </application>
-  </manifest>
-  
+  <application>
+    <service android:enabled="true" android:name="com.getcapacitor.community.bglocation.LocationUpdatesService" />
+  </application>
+</manifest>

--- a/android/src/main/java/com/getcapacitor/community/bglocation/BackgroundGeolocation.java
+++ b/android/src/main/java/com/getcapacitor/community/bglocation/BackgroundGeolocation.java
@@ -25,6 +25,7 @@ import com.getcapacitor.PluginMethod;
   permissions = {
     Manifest.permission.FOREGROUND_SERVICE,
     Manifest.permission.ACCESS_FINE_LOCATION,
+    Manifest.permission.ACCESS_BACKGROUND_LOCATION,
   },
   permissionRequestCode = 86 // Used in checking for runtime permissions.
 )

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "capacitor-background-geolocation",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "A native plugin to get geolocation updates also when app is in background",
   "main": "dist/plugin.js",
   "module": "dist/esm/index.js",


### PR DESCRIPTION
Fixes #14 
Adds permission for BackgroundGeolocation, needed from Android 10 (SDK 29) or later.

Docs: https://developer.android.com/training/location/permissions#background